### PR TITLE
use renamed aggregation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Scripts will be found at root level.
 
 ## Installation
 
-The scripts depend on a number of PACTA related R packages, most of which can be found on CRAN. However, you will need to install the development version of `pacta.supervisor.analysis` from [GitHub](https://github.com/) with:
+The scripts depend on a number of PACTA related R packages, most of which can be found on CRAN. However, you will need to install the development version of `pacta.aggregate.loanbook.plots` from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("RMI-PACTA/pacta.supervisor.analysis")
+devtools::install_github("RMI-PACTA/pacta.aggregate.loanbook.plots")
 ```
 
 ## dotenv

--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -1,7 +1,7 @@
 # load packages----
 library(dotenv)
 library(dplyr)
-library(pacta.supervisor.analysis)
+library(pacta.aggregate.loanbook.plots)
 library(r2dii.analysis)
 library(r2dii.data)
 library(r2dii.match)


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/pacta.supervisor.analysis/pull/57

the R package used to calculate the alignment aggregation is renamed from `pacta.supervisor.analysis` to `pacta.aggregate.loanbook.plots`, hence all references to that package are updated in this workflow