### PR TITLE
rm obsolete arg from function call of sda aggregation

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -452,7 +452,6 @@ if (scenario_source_input == "geco_2021" & scenario_select == "1.5c") {scenario_
 
 company_aggregated_alignment_net_sda <- sda_result_for_aggregation %>%
   calculate_company_aggregate_alignment_sda(
-    scenario_emission_intensities = scenario_input_sda,
     scenario_source = scenario_source_input,
     scenario = scenario_select_sda
   )


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/pacta.aggregate.loanbook.plots/pull/62

remove obsolete argument from function call