### PR TITLE
ensure subdirectories for each group exist in aggregate results

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -578,7 +578,7 @@ if (
   )
 }
 
-## group level plots ----
+# group level plots ----
 ### timeline plot: evolution of portfolio-weighted alignment over time----
 
 region_timeline <- region_select
@@ -591,6 +591,10 @@ unique_loanbook_group_id <- loanbook_exposure_aggregated_alignment_bo_po %>%
   ) %>%
   dplyr::pull(.data$group_id) %>%
   unique()
+
+for (i in unique_loanbook_group_id) {
+  dir.create(file.path(output_path_aggregated, i), showWarnings = FALSE)
+}
 
 for (i in unique_loanbook_group_id) {
   data_timeline <- prep_timeline(


### PR DESCRIPTION
we need to ensure that subdirectories for all available groups are created in the aggregate result folder before trying to save graphs in that directory. Otherwise the script will not be able to access the path when writing and error out