### PR TITLE
Simplify benchmark loanbook

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -139,7 +139,7 @@ for (i in benchmark_regions) {
       benchmark_region = i
     )
 
-  matched_benchmark_i <- match_name(loanbook_corporate_benchmark_i, abcd) %>%
+  matched_benchmark_i <- loanbook_corporate_benchmark_i %>%
     prioritize()
 
   matched_benchmark <- matched_benchmark %>%

--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -46,8 +46,22 @@ benchmark_regions <- unlist(base::strsplit(Sys.getenv("PARAM_BENCHMARK_REGIONS")
 ############# TEMP #############
 # r2dii.data is not updated yet, so we manually update the region_isos data to
 # cover the 2022 scenarios
-regions_geco_2022 <- readr::read_csv(input_path_regions_geco_2022)
-regions_weo_2022 <- readr::read_csv(input_path_regions_weo_2022)
+regions_geco_2022 <- readr::read_csv(
+  input_path_regions_geco_2022,
+  col_types = cols_only(
+    region = "c",
+    isos = "c",
+    source = "c"
+  )
+)
+regions_weo_2022 <- readr::read_csv(
+  input_path_regions_weo_2022,
+  col_types = cols_only(
+    region = "c",
+    isos = "c",
+    source = "c"
+  )
+)
 
 region_isos_complete <- r2dii.data::region_isos %>%
   rbind(regions_geco_2022) %>%
@@ -62,11 +76,51 @@ region_isos_select <- region_isos_complete %>%
   )
 
 # load input data----
-scenario_input_tms <- read.csv(input_path_scenario_tms)
-scenario_input_sda <- read.csv(input_path_scenario_sda)
+scenario_input_tms <- readr::read_csv(
+  input_path_scenario_tms,
+  col_types = cols_only(
+    scenario_source = "c",
+    region = "c",
+    scenario = "c",
+    sector = "c",
+    technology = "c",
+    year = "i",
+    smsp = "n",
+    tmsr = "n"
+  )
+)
+scenario_input_sda <- readr::read_csv(
+  input_path_scenario_sda,
+  col_types = cols_only(
+    scenario_source = "c",
+    region = "c",
+    scenario = "c",
+    sector = "c",
+    year = "i",
+    emission_factor = "n",
+    emission_factor_unit = "c"
+  )
+)
 
 # abcd <- abcd_test_data
-abcd <- readr::read_csv(file.path(input_path_abcd))
+abcd <- readr::read_csv(
+  file.path(input_path_abcd),
+  col_types = cols_only(
+    company_id = "i",
+    name_company = "c",
+    lei = "c",
+    is_ultimate_owner = "l",
+    sector = "c",
+    technology = "c",
+    plant_location = "c",
+    year = "i",
+    production = "n",
+    production_unit = "c",
+    emission_factor = "n",
+    emission_factor_unit = "c",
+    ald_timestamp = "c"
+  )
+)
 # replace potential NA values with 0 in production
 abcd["production"][is.na(abcd["production"])] <- 0
 
@@ -97,7 +151,38 @@ matched_benchmark %>%
 
 # read matched and prioritized loan book----
 matched_prioritized <- readr::read_csv(
-  file.path(input_path_matched, "matched_prio_all_groups.csv")
+  file.path(input_path_matched, "matched_prio_all_groups.csv"),
+  col_types = cols(
+    group_id = "c",
+    id_loan = "c",
+    id_direct_loantaker = "c",
+    name_direct_loantaker = "c",
+    id_intermediate_parent_1 = "c",
+    name_intermediate_parent_1 = "c",
+    id_ultimate_parent = "c",
+    name_ultimate_parent = "c",
+    loan_size_outstanding = "n",
+    loan_size_outstanding_currency = "c",
+    loan_size_credit_limit = "n",
+    loan_size_credit_limit_currency = "c",
+    sector_classification_system = "c",
+    sector_classification_input_type = "c",
+    sector_classification_direct_loantaker = "n",
+    fi_type = "c",
+    flag_project_finance_loan = "c",
+    name_project = "c",
+    lei_direct_loantaker = "c",
+    isin_direct_loantaker = "c",
+    id_2dii = "c",
+    level = "c",
+    sector = "c",
+    sector_abcd = "c",
+    name = "c",
+    name_abcd = "c",
+    score = "n",
+    source = "c",
+    borderline = "l"
+  )
 )
 
 # aggregate P4B alignment----


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/pacta.aggregate.loanbook.plots/pull/82

This PR:
- adapts the generation of the matched loan book to the updated version that returns a matched loan book already
- explicitly states col type expectations when reading csv files in aggregate workflow