### PR TITLE
use new logic of create_benchmark

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -77,16 +77,13 @@ matched_benchmark <- NULL
 # matching the benchmark loan book separately, because it is not needed for the
 # generation of standard PACTA output
 for (i in benchmark_regions) {
-  loanbook_corporate_benchmark_i <- abcd %>%
+  matched_benchmark_i <- abcd %>%
     create_benchmark_loanbook(
       scenario_source = scenario_source_input,
       start_year = start_year,
       region_isos = region_isos_complete,
       benchmark_region = i
     )
-
-  matched_benchmark_i <- match_name(loanbook_corporate_benchmark_i, abcd) %>%
-    prioritize()
 
   matched_benchmark <- matched_benchmark %>%
     dplyr::bind_rows(matched_benchmark_i)


### PR DESCRIPTION
supersedes #24 

depends on https://github.com/RMI-PACTA/pacta.aggregate.loanbook.plots/pull/82

This PR:

- adapts the generation of the matched loan book to the updated version that returns a matched loan book already