### PR TITLE
ensure the SDA results have no values smaller than start year

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -408,7 +408,8 @@ for (i in unique_benchmarks_sda) {
 # bind the SDA results from the loan book and benchmark PACTA runs for further
 # aggregation
 sda_result_for_aggregation <- sda_result_for_aggregation %>%
-  dplyr::bind_rows(sda_result_for_aggregation_benchmark)
+  dplyr::bind_rows(sda_result_for_aggregation_benchmark) %>%
+  dplyr::filter(.data$year >= .env$start_year)
 
 ## aggregate SDA P4B results to company level alignment metric----
 # calculate aggregation for the loan book


### PR DESCRIPTION
If ABCD contains years < start year of the SDA scenarios, the SDA result will have entries for such years. This leads to problems in the sankey plot which uses the first available year + 5. However, the first useful result (correctly) starts in t = start_year for the SDA results. Any rows before the start year are therefore removed before the creation of plots.