### PR TITLE
get rid of warning related to col_select

### DIFF
--- a/run_pacta_in_bulk.R
+++ b/run_pacta_in_bulk.R
@@ -57,12 +57,12 @@ if (file.exists(here::here(".env"))) {
 regions_geco_2022 <- readr::read_csv(
   input_path_regions_geco_2022,
   col_types = col_types_region_isos,
-  col_select = col_select_region_isos
+  col_select = dplyr::all_of(col_select_region_isos)
 )
 regions_weo_2022 <- readr::read_csv(
   input_path_regions_weo_2022,
   col_types = col_types_region_isos,
-  col_select = col_select_region_isos
+  col_select = dplyr::all_of(col_select_region_isos)
 )
 
 region_isos_complete <- r2dii.data::region_isos %>%


### PR DESCRIPTION
this removes warnings that are related to previously not using `dplyr::all_of()` when selecting multiple columns via a character vector