### PR TITLE
Sector split all companies

### DIFF
--- a/R/functions_prep_project.R
+++ b/R/functions_prep_project.R
@@ -35,6 +35,9 @@ apply_sector_split_to_loans <- function(data,
                                         abcd,
                                         companies_sector_split,
                                         sector_split_type) {
+  unique_companies_pre_split <- data %>%
+    distinct(name_abcd)
+
   if (sector_split_type == "equal_weights") {
     abcd_id <- abcd %>%
       dplyr::distinct(.data$company_id, .data$name_company)
@@ -68,4 +71,20 @@ apply_sector_split_to_loans <- function(data,
       )
     ) %>%
     dplyr::select(-"sector_split")
+
+  unique_companies_post_split <- data %>%
+    distinct(name_abcd)
+
+  if (nrow(unique_companies_pre_split) != nrow(unique_companies_post_split)) {
+    warning(
+      glue::glue(
+        "Applying the sector split has lead to changes in the number of unique
+        companies covered in the analysis. Prior to the split, there were
+        {nrow(unique_companies_pre_split)} unique companies. After the split,
+        there are {nrow(unique_companies_post_split)} unique companies."
+      )
+    )
+  }
+
+  return(data)
 }

--- a/README.md
+++ b/README.md
@@ -110,21 +110,31 @@ Once you have set up the .env file correctly, you can simply run the
   - Scatter plot that allows for peer comparison of alignment metric
     across companies or groups (automotive and power sectors only)
 
-### Optional: Calculate sector splits for multi-sector energy companies
+### Optional: Calculate sector splits for multi-sector companies
 
-You can optionally calculate an activity-based sector split for
-companies that have at least two energy-related main business lines
-withing PACTA scope (at least two of: coal mining, upstream oil & gas,
-power generation). This sector split is meant to help with allocating
-portions of a loan to each of the relevant business lines. As such, it
-allows for considering more than one main sector. This improves
-coverage of transition activities and reflects better the multi-sector focus of
-some companies.
+You can optionally generate a sector split file. This can be used to split the
+loan exposure of a counterparty across the in-scope sectors the company operates
+in. The way the split is calculated can be adjusted and should be informed by
+the particular use case / research question to be answered.
+
+Currently, two basic and one advanced variants of the sector split exist. The
+basic variants are (1) an equal weights split, which allocates the loan equally
+among the sectors a counterparty operates in and (2) a worst case split, which
+allocates the entire loan to the sector that is most misaligned for the given
+counterparty.
+
+An advanced variant calculates an activity-based sector split for companies that
+have at least two energy-related main business lines withing PACTA scope (at
+least two of: coal mining, upstream oil & gas, power generation). This sector
+split is meant to help with allocating portions of a loan to each of the
+relevant business lines. As such, it allows for considering more than one main
+sector. This improves coverage of transition activities and reflects better the
+multi-sector focus of some companies.
 
 To get this sector split, you will need some additional input files:
 
 - a csv containing one column `company_id` that lists the companies you
-  would like to get the sector split for.
+  would like to get the activity-based sector split for.
 - an `advanced_company_indicators` file that includes activity units for
   all three in-scope energy sectors, where the units must be tons of
   coal for coal mining, GJ for upstream oil & gas and MWh for power

--- a/prep_sector_split.R
+++ b/prep_sector_split.R
@@ -185,11 +185,7 @@ multi_sector_companies_prep <- advanced_company_indicators %>%
     .by = c("company_id", "n_sectors")
   )
 
-### identify compenies active in more than one sector----
-# multi_sector_companies_all <- multi_sector_companies_prep %>%
-#   dplyr::filter(.data$n_sectors > 1)
-
-### identify compenies active in more than one energy sector----
+### identify companies active in more than one energy sector----
 multi_sector_companies_energy <- multi_sector_companies_prep %>%
   dplyr::filter(.data$n_energy_sectors > 1) %>%
   dplyr::pull(.data$company_id)
@@ -207,7 +203,6 @@ sector_split_all_companies <- advanced_company_indicators %>%
   ) %>%
   dplyr::inner_join(
     multi_sector_companies_prep,
-    # multi_sector_companies_all,
     by = "company_id"
   ) %>%
   dplyr::mutate(

--- a/prep_sector_split.R
+++ b/prep_sector_split.R
@@ -186,8 +186,8 @@ multi_sector_companies_prep <- advanced_company_indicators %>%
   )
 
 ### identify compenies active in more than one sector----
-multi_sector_companies_all <- multi_sector_companies_prep %>%
-  dplyr::filter(.data$n_sectors > 1)
+# multi_sector_companies_all <- multi_sector_companies_prep %>%
+#   dplyr::filter(.data$n_sectors > 1)
 
 ### identify compenies active in more than one energy sector----
 multi_sector_companies_energy <- multi_sector_companies_prep %>%
@@ -206,7 +206,8 @@ sector_split_all_companies <- advanced_company_indicators %>%
     .data$year == .env$start_year
   ) %>%
   dplyr::inner_join(
-    multi_sector_companies_all,
+    multi_sector_companies_prep,
+    # multi_sector_companies_all,
     by = "company_id"
   ) %>%
   dplyr::mutate(
@@ -273,7 +274,9 @@ sector_split_energy_companies <- sector_split_energy_companies %>%
   ) %>%
   dplyr::select(
     dplyr::all_of(c("company_id", "name_company", "sector", "production_unit", "production", "sector_split"))
-  )
+  ) %>%
+  dplyr::filter(.data$company_id %in% company_ids_included)
+
 
 check_sector_split_energy_companies <- sector_split_energy_companies %>%
   dplyr::summarise(
@@ -317,7 +320,6 @@ if (any(round(check_sector_split_all_companies_final$sum_share, 3) != 1)) {
 
 ## write output----
 sector_split_energy_companies %>%
-  dplyr::filter(.data$company_id %in% company_ids_included) %>%
   dplyr::select(
     all_of(
       c("company_id", "name_company", "sector", "sector_split")
@@ -326,7 +328,6 @@ sector_split_energy_companies %>%
   readr::write_csv(file.path(input_path_matched, "companies_sector_split_energy_only.csv"))
 
 sector_split_all_companies %>%
-  dplyr::filter(.data$company_id %in% company_ids_included) %>%
   dplyr::select(
     all_of(
       c("company_id", "name_company", "sector", "sector_split")
@@ -335,7 +336,6 @@ sector_split_all_companies %>%
   readr::write_csv(file.path(input_path_matched, "companies_sector_split_equal_weights_only.csv"))
 
 sector_split_all_companies_final %>%
-  dplyr::filter(.data$company_id %in% company_ids_included) %>%
   dplyr::select(
     all_of(
       c("company_id", "name_company", "sector", "sector_split")


### PR DESCRIPTION
closes #41 

This PR:
- returns sector spit values for all available companies rather than just for a selected sample of companies.
- the sample of company ids is now restricted to calculating the primary energy based sector split, not the generic equal weights and worst case sector splits
- This allows inner_joining the sector split on the matched loan book without removing company coverage while providing valid sector split values for all companies
- The sector split function also throws a warning if the split introduces a change in coverage of the number of companies in the matched loan book