### PR TITLE
ensure prepared loan books are not duplicated

### DIFF
--- a/example.env
+++ b/example.env
@@ -39,3 +39,5 @@ SAMPLE_EXPOSURE=100000000
 SAMPLE_CREDIT_LIMIT=500000000
 SAMPLE_CURRENCY="USD"
 
+# parameters for matching input loan books
+PREP_INPUT_LEVEL="direct_loantaker"

--- a/prep_input_loanbooks.R
+++ b/prep_input_loanbooks.R
@@ -28,6 +28,8 @@ if (file.exists(here::here(".env"))) {
   input_path_abcd <- file.path(input_dir_abcd, Sys.getenv("FILENAME_ABCD"))
 
   output_path <- Sys.getenv("DIR_OUTPUT")
+
+  match_level <- Sys.getenv("PREP_INPUT_LEVEL")
 } else {
   stop("Please set up a configuration file at the root of the repository, as
        explained in the README.md")
@@ -136,7 +138,8 @@ for (i in unique_matched_loanbook_checked) {
     dplyr::filter(.data$group_id == i)
 
   matched_prioritized_i <- matched_loanbook_checked_i %>%
-    prioritize()
+    prioritize() %>%
+    dplyr::filter(.data$level == .env$match_level)
 
   matched_prioritized <- matched_prioritized %>%
     dplyr::bind_rows(matched_prioritized_i)


### PR DESCRIPTION
This PR:

- ensure the internally-used script `prep_input_loanbooks.R` does not accidentally return matched loanbooks both on the `direct_loantaker` and the `ultimate_parent` levels, which would artificially duplicate the exposure covered