### PR TITLE
remove_inactive_companies additionally removes cases of zero total production

### DIFF
--- a/R/functions_prep_project.R
+++ b/R/functions_prep_project.R
@@ -22,9 +22,28 @@ rm_inactive_companies <- function(data,
   comp_sec_no_prod_t5 <- data_no_prod_t5 %>%
     dplyr::distinct(.data$name_company, .data$sector)
 
+  data_no_prod_t0_to_t5 <- data %>%
+    dplyr::filter(
+      year %in% c(.env$start_year, .env$start_year + .env$time_frame_select)
+    ) %>%
+    dplyr::summarise(
+      sum_production = sum(production, na.rm = TRUE),
+      .by =c("name_company", "sector")
+    ) %>%
+    dplyr::filter(
+      .data$sum_production == 0
+    )
+
+  comp_sec_no_prod_t0_to_t5 <- data_no_prod_t0_to_t5 %>%
+    dplyr::distinct(.data$name_company, .data$sector)
+
   data <- data %>%
     dplyr::anti_join(
       comp_sec_no_prod_t5,
+      by = c("name_company", "sector")
+    ) %>%
+    dplyr::anti_join(
+      comp_sec_no_prod_t0_to_t5,
       by = c("name_company", "sector")
     )
 

--- a/R/functions_prep_project.R
+++ b/R/functions_prep_project.R
@@ -6,7 +6,7 @@ rm_inactive_companies <- function(data,
       year %in% c(.env$start_year, .env$start_year + .env$time_frame_select)
     ) %>%
     dplyr::summarise(
-      sum_production = sum(production, na.rm = TRUE),
+      sum_production = sum(.data$production, na.rm = TRUE),
       .by =c("name_company", "sector", "year")
     ) %>%
     tidyr::pivot_wider(
@@ -27,7 +27,7 @@ rm_inactive_companies <- function(data,
       year %in% c(.env$start_year, .env$start_year + .env$time_frame_select)
     ) %>%
     dplyr::summarise(
-      sum_production = sum(production, na.rm = TRUE),
+      sum_production = sum(.data$production, na.rm = TRUE),
       .by =c("name_company", "sector")
     ) %>%
     dplyr::filter(

--- a/prep_sector_split.R
+++ b/prep_sector_split.R
@@ -171,7 +171,6 @@ advanced_company_indicators <- advanced_company_indicators_raw %>%
     start_year = start_year,
     time_frame_select = time_frame_select
   ) %>%
-  # TODO: remove companies/sector combinations that are 0 throughout the time frame in question
   dplyr::filter(.data$year == .env$start_year)
 
 ### count number of sectors and energy sectors per company----


### PR DESCRIPTION
This PR:
- ensures that the function remove_inactive_companies() additionally removes company_sector combinations from the abcd that have a sum of 0 production over the given timeframe
- previously it only removed combinations that start with a positive value and end on zero production (so a company leaving a sector)
- the new addition is helpful to keep only companies from the advanced company indicators that are also given in the P4B abcd.
  - advanced company indicators are e.g. used to determine company lists when creating the sector split.
  - It therefore ensures that no companies are considered "lost" that could not be matched to the P4B abcd in the first place.