### PR TITLE
remove reliance on region helper files in favor of r2dii.data::region_isos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ DIR_OUTPUT="PATH/TO/OUTPUT/FOLDER"
 # input file names
 FILENAME_SCENARIO_TMS="scenario_tms.csv"
 FILENAME_SCENARIO_SDA="scenario_sda.csv"
-FILENAME_REGIONS_GECO_2022="region_geco2022.csv"
-FILENAME_REGIONS_WEO_2022="region_weo2022.csv"
 FILENAME_ABCD="abcd_data.csv"
 
 # project parameters

--- a/example.env
+++ b/example.env
@@ -8,8 +8,6 @@ DIR_OUTPUT="PATH/TO/OUTPUT/FOLDER"
 # input file names
 FILENAME_SCENARIO_TMS="scenario_tms.csv"
 FILENAME_SCENARIO_SDA="scenario_sda.csv"
-FILENAME_REGIONS_GECO_2022="region_geco2022.csv"
-FILENAME_REGIONS_WEO_2022="region_weo2022.csv"
 FILENAME_ABCD="abcd_data.csv"
 
 # project parameters

--- a/prep_input_loanbooks.R
+++ b/prep_input_loanbooks.R
@@ -21,8 +21,6 @@ if (file.exists(here::here(".env"))) {
   input_path_raw <- Sys.getenv("DIR_RAW")
   input_path_matched <- Sys.getenv("DIR_MATCHED")
 
-  input_path_regions_geco_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_GECO_2022"))
-  input_path_regions_weo_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_WEO_2022"))
   input_path_scenario_tms <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_TMS"))
   input_path_scenario_sda <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_SDA"))
   input_path_abcd <- file.path(input_dir_abcd, Sys.getenv("FILENAME_ABCD"))
@@ -42,26 +40,8 @@ region_select <- Sys.getenv("PARAM_REGION_SELECT")
 
 # TODO: add check if all files exist, resort to test files if not
 
-# TODO: remove the temp section once r2dii.data is updated
-############# TEMP #############
-# r2dii.data is not updated yet, so we manually update the region_isos data to
-# cover the 2022 scenarios
-regions_geco_2022 <- readr::read_csv(
-  input_path_regions_geco_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-regions_weo_2022 <- readr::read_csv(
-  input_path_regions_weo_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-
-region_isos_complete <- r2dii.data::region_isos %>%
-  rbind(regions_geco_2022) %>%
-  rbind(regions_weo_2022)
-################################
-# region_isos_complete <- r2dii.data::region_isos
+# load input data----
+region_isos_complete <- r2dii.data::region_isos
 
 region_isos_select <- region_isos_complete %>%
   dplyr::filter(
@@ -69,7 +49,6 @@ region_isos_select <- region_isos_complete %>%
     .data$region %in% .env$region_select
   )
 
-# load input data----
 scenario_input_tms <- readr::read_csv(
   input_path_scenario_tms,
   col_types = col_types_scenario_tms,

--- a/prep_sample_loanbook_raw.R
+++ b/prep_sample_loanbook_raw.R
@@ -40,8 +40,8 @@ abcd <- readr::read_csv(
 abcd["production"][is.na(abcd["production"])] <- 0
 
 # Optional: sample only companies which have some production in a selected region_sample
-region_companies_source <- "weo_2021"
-region_companies <- "europe"
+region_companies_source <- "geco_2022"
+region_companies <- "canada"
 region_sample <- r2dii.data::region_isos %>%
   dplyr::filter(
     .data$source == .env$region_companies_source,

--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -22,8 +22,6 @@ if (file.exists(here::here(".env"))) {
   input_dir_abcd <- Sys.getenv("DIR_ABCD")
   input_path_matched <- Sys.getenv("DIR_MATCHED")
 
-  input_path_regions_geco_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_GECO_2022"))
-  input_path_regions_weo_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_WEO_2022"))
   input_path_scenario_tms <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_TMS"))
   input_path_scenario_sda <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_SDA"))
   input_path_abcd <- file.path(input_dir_abcd, Sys.getenv("FILENAME_ABCD"))
@@ -58,26 +56,9 @@ if (file.exists(here::here(".env"))) {
 
 # TODO: add check if all files exist, resort to test files if not
 
-# TODO: remove the temp section once r2dii.data is updated
-############# TEMP #############
-# r2dii.data is not updated yet, so we manually update the region_isos data to
-# cover the 2022 scenarios
-regions_geco_2022 <- readr::read_csv(
-  input_path_regions_geco_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-regions_weo_2022 <- readr::read_csv(
-  input_path_regions_weo_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
 
-region_isos_complete <- r2dii.data::region_isos %>%
-  rbind(regions_geco_2022) %>%
-  rbind(regions_weo_2022)
-################################
-# region_isos_complete <- r2dii.data::region_isos
+# load input data----
+region_isos_complete <- r2dii.data::region_isos
 
 region_isos_select <- region_isos_complete %>%
   dplyr::filter(
@@ -85,7 +66,6 @@ region_isos_select <- region_isos_complete %>%
     .data$region %in% .env$region_select
   )
 
-# load input data----
 scenario_input_tms <- readr::read_csv(
   input_path_scenario_tms,
   col_types = col_types_scenario_tms,

--- a/run_calculate_coverage.R
+++ b/run_calculate_coverage.R
@@ -10,8 +10,6 @@ if (file.exists(here::here(".env"))) {
   input_path_scenario <- Sys.getenv("DIR_SCENARIO")
   input_dir_abcd <- Sys.getenv("DIR_ABCD")
 
-  input_path_regions_geco_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_GECO_2022"))
-  input_path_regions_weo_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_WEO_2022"))
   input_path_scenario_tms <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_TMS"))
   input_path_scenario_sda <- file.path(input_path_scenario, Sys.getenv("FILENAME_SCENARIO_SDA"))
   input_path_abcd <- file.path(input_dir_abcd, Sys.getenv("FILENAME_ABCD"))
@@ -36,20 +34,7 @@ abcd <- readr::read_csv(
 abcd["production"][is.na(abcd["production"])] <- 0
 
 ## get region and countries for analysis----
-regions_geco_2022 <- readr::read_csv(
-  input_path_regions_geco_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-regions_weo_2022 <- readr::read_csv(
-  input_path_regions_weo_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-
-region_isos_complete <- r2dii.data::region_isos %>%
-  rbind(regions_geco_2022) %>%
-  rbind(regions_weo_2022)
+region_isos_complete <- r2dii.data::region_isos
 
 region_isos_select <- region_isos_complete %>%
   dplyr::filter(

--- a/run_calculate_loanbook_coverage.R
+++ b/run_calculate_loanbook_coverage.R
@@ -18,9 +18,6 @@ if (file.exists(here::here(".env"))) {
   input_dir_abcd <- Sys.getenv("DIR_ABCD")
   input_path_matched <- Sys.getenv("DIR_MATCHED")
 
-  input_path_regions_geco_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_GECO_2022"))
-  input_path_regions_weo_2022 <- file.path(input_path_scenario, Sys.getenv("FILENAME_REGIONS_WEO_2022"))
-
   input_path_abcd <- file.path(input_dir_abcd, Sys.getenv("FILENAME_ABCD"))
 
   output_path <- input_path_matched
@@ -117,20 +114,8 @@ if (apply_sector_split & sector_split_type_select %in% c("equal_weights", "worst
 matched_companies <- matched_prioritized %>%
   distinct(name_abcd, sector_abcd, loan_size_outstanding, loan_size_outstanding_currency, score)
 
-regions_geco_2022 <- readr::read_csv(
-  input_path_regions_geco_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-regions_weo_2022 <- readr::read_csv(
-  input_path_regions_weo_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
 # get required countries for region_select----
-region_isos_complete <- r2dii.data::region_isos %>%
-  rbind(regions_geco_2022) %>%
-  rbind(regions_weo_2022)
+region_isos_complete <- r2dii.data::region_isos
 
 region_isos_select <- region_isos_complete %>%
   dplyr::filter(

--- a/run_pacta_in_bulk.R
+++ b/run_pacta_in_bulk.R
@@ -58,26 +58,8 @@ if (file.exists(here::here(".env"))) {
 
 # TODO: add check if all files exist, resort to test files if not
 
-# TODO: remove the temp section once r2dii.data is updated
-############# TEMP #############
-# r2dii.data is not updated yet, so we manually update the region_isos data to
-# cover the 2022 scenarios
-regions_geco_2022 <- readr::read_csv(
-  input_path_regions_geco_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-regions_weo_2022 <- readr::read_csv(
-  input_path_regions_weo_2022,
-  col_types = col_types_region_isos,
-  col_select = dplyr::all_of(col_select_region_isos)
-)
-
-region_isos_complete <- r2dii.data::region_isos %>%
-  rbind(regions_geco_2022) %>%
-  rbind(regions_weo_2022)
-################################
-# region_isos_complete <- r2dii.data::region_isos
+# load input data----
+region_isos_complete <- r2dii.data::region_isos
 
 region_isos_select <- region_isos_complete %>%
   dplyr::filter(
@@ -85,7 +67,6 @@ region_isos_select <- region_isos_complete %>%
     .data$region %in% .env$region_select
   )
 
-# load input data----
 scenario_input_tms <- readr::read_csv(
   input_path_scenario_tms,
   col_types = col_types_scenario_tms,


### PR DESCRIPTION
this PR removes the need to load region isos mappers for current scenarios, as these are now all included in the latest r2dii.data releases available on CRAN