### PR TITLE
plot net aggregate alignment by financial exposure

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -56,12 +56,12 @@ plot_scatter_alignment_exposure <- function(data,
   }
 
   title <- glue::glue("Net Aggregate Alignment By Financial Exposure And Sector")
-  subtitle <- glue::glue("Groups Displayed: Bank Types")
+  subtitle <- ""
   # TODO: this should be variable and any categorical variable should be able to be used
   # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}")
   if (any(!is.null(floor_outliers), !is.null(cap_outliers))) {
     subtitle <- glue::glue(
-      "{subtitle}\nThe outliers are displayed on the borders of the plot.",
+      "{subtitle}Outliers are displayed on the lower and upper boundaries: {floor_outliers} and {cap_outliers}.",
       .trim = FALSE
     )
   }
@@ -72,11 +72,13 @@ plot_scatter_alignment_exposure <- function(data,
       ggplot2::aes(
         x = sum_loan_size_outstanding,
         y = exposure_weighted_net_alignment,
-        # TODO: this should be variable and any categorical variable should be able to be used
         color = !!rlang::sym(category)
       )
     ) +
     ggplot2::geom_point() +
+    ggplot2::geom_hline(yintercept = 0) +
+    ggplot2::ylim(-1, 1) +
+    ggplot2::scale_x_continuous(labels = scales::comma) +
     ggplot2::facet_wrap(
       ~ sector
     ) +
@@ -87,12 +89,15 @@ plot_scatter_alignment_exposure <- function(data,
       # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}"),
       color = r2dii.plot::to_title(category)
     ) +
-    ggplot2::xlab(glue::glue("Financial Exposure (in {currency})")) +
+    # TODO: this label must be generalized
+    ggplot2::xlab(glue::glue("Financial Exposure (in 1000 {currency})")) +
     ggplot2::ylab("Net Aggregate Alignment") +
     r2dii.plot::scale_colour_r2dii() +
     ggplot2::theme_bw() +
     ggplot2::theme(
-      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1)
+      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1),
+      panel.grid = ggplot2::element_blank()
+      # panel.grid.minor = ggplot2::element_blank()
     )
 
   plot

--- a/R/plots.R
+++ b/R/plots.R
@@ -1,0 +1,99 @@
+prep_scatter_alignment_exposure <- function(data,
+                                            year,
+                                            region,
+                                            scenario) {
+  data <- data %>%
+    dplyr::filter(!grepl("benchmark_", .data$group_id)) %>%
+    dplyr::filter(
+      .data$year == .env$year,
+      .data$region == .env$region,
+      .data$scenario == .env$scenario
+    ) %>%
+    dplyr::select(
+      dplyr::all_of(
+        c(
+          .env$category,
+          # "group_id",
+          "scenario",
+          "region",
+          "sector",
+          "year",
+          "exposure_weighted_net_alignment",
+          "sum_loan_size_outstanding"
+        )
+      )
+    )
+
+  data
+}
+
+plot_scatter_alignment_exposure <- function(data,
+                                            floor_outliers,
+                                            cap_outliers,
+                                            category,
+                                            currency) {
+
+  if (!is.null(floor_outliers)) {
+    data <- data %>%
+      mutate(
+        exposure_weighted_net_alignment = if_else(
+          .data$exposure_weighted_net_alignment <= .env$floor_outliers,
+          .env$floor_outliers,
+          .data$exposure_weighted_net_alignment
+        )
+      )
+  }
+
+  if (!is.null(cap_outliers)) {
+    data <- data %>%
+      mutate(
+        exposure_weighted_net_alignment = if_else(
+          .data$exposure_weighted_net_alignment >= .env$cap_outliers,
+          .env$cap_outliers,
+          .data$exposure_weighted_net_alignment
+        )
+      )
+  }
+
+  title <- glue::glue("Net Aggregate Alignment By Financial Exposure And Sector")
+  subtitle <- glue::glue("Groups Displayed: Bank Types")
+  # TODO: this should be variable and any categorical variable should be able to be used
+  # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}")
+  if (any(!is.null(floor_outliers), !is.null(cap_outliers))) {
+    subtitle <- glue::glue(
+      "{subtitle}\nThe outliers are displayed on the borders of the plot.",
+      .trim = FALSE
+    )
+  }
+
+  plot <- data %>%
+    dplyr::mutate(sector = tools::toTitleCase(.data$sector)) %>%
+    ggplot2::ggplot(
+      ggplot2::aes(
+        x = sum_loan_size_outstanding,
+        y = exposure_weighted_net_alignment,
+        # TODO: this should be variable and any categorical variable should be able to be used
+        color = !!rlang::sym(category)
+      )
+    ) +
+    ggplot2::geom_point() +
+    ggplot2::facet_wrap(
+      ~ sector
+    ) +
+    ggplot2::labs(
+      title = title,
+      subtitle = subtitle,
+      # TODO: this should be variable and any categorical variable should be able to be used
+      # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}"),
+      color = r2dii.plot::to_title(category)
+    ) +
+    ggplot2::xlab(glue::glue("Financial Exposure (in {currency})")) +
+    ggplot2::ylab("Net Aggregate Alignment") +
+    r2dii.plot::scale_colour_r2dii() +
+    ggplot2::theme_bw() +
+    ggplot2::theme(
+      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1)
+    )
+
+  plot
+}

--- a/R/plots.R
+++ b/R/plots.R
@@ -88,8 +88,7 @@ plot_scatter_alignment_exposure <- function(data,
       subtitle = subtitle,
       color = r2dii.plot::to_title(category)
     ) +
-    # TODO: this label must be generalized
-    ggplot2::xlab(glue::glue("Financial Exposure (in 1000 {currency})")) +
+    ggplot2::xlab(glue::glue("Financial Exposure (in {currency})")) +
     ggplot2::ylab("Net Aggregate Alignment") +
     r2dii.plot::scale_colour_r2dii() +
     ggplot2::theme_bw() +

--- a/R/plots.R
+++ b/R/plots.R
@@ -1,9 +1,13 @@
 prep_scatter_alignment_exposure <- function(data,
                                             year,
                                             region,
-                                            scenario) {
+                                            scenario,
+                                            category,
+                                            exclude_group_ids = "benchmark") {
   data <- data %>%
-    dplyr::filter(!grepl("benchmark_", .data$group_id)) %>%
+    dplyr::filter(
+      !grepl(paste0(.env$exclude_group_ids, collapse = "|"), .data$group_id)
+    ) %>%
     dplyr::filter(
       .data$year == .env$year,
       .data$region == .env$region,
@@ -13,7 +17,6 @@ prep_scatter_alignment_exposure <- function(data,
       dplyr::all_of(
         c(
           .env$category,
-          # "group_id",
           "scenario",
           "region",
           "sector",

--- a/R/plots.R
+++ b/R/plots.R
@@ -95,7 +95,6 @@ plot_scatter_alignment_exposure <- function(data,
     ggplot2::theme(
       axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1),
       panel.grid = ggplot2::element_blank()
-      # panel.grid.minor = ggplot2::element_blank()
     )
 
   plot

--- a/R/plots.R
+++ b/R/plots.R
@@ -60,8 +60,6 @@ plot_scatter_alignment_exposure <- function(data,
 
   title <- glue::glue("Net Aggregate Alignment By Financial Exposure And Sector")
   subtitle <- ""
-  # TODO: this should be variable and any categorical variable should be able to be used
-  # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}")
   if (any(!is.null(floor_outliers), !is.null(cap_outliers))) {
     subtitle <- glue::glue(
       "{subtitle}Outliers are displayed on the lower and upper boundaries: {floor_outliers} and {cap_outliers}.",
@@ -88,8 +86,6 @@ plot_scatter_alignment_exposure <- function(data,
     ggplot2::labs(
       title = title,
       subtitle = subtitle,
-      # TODO: this should be variable and any categorical variable should be able to be used
-      # subtitle = glue::glue("Groups Displayed: {tools::toTitleCase(sector)}"),
       color = r2dii.plot::to_title(category)
     ) +
     # TODO: this label must be generalized

--- a/plot_aggregate_loanbooks.R
+++ b/plot_aggregate_loanbooks.R
@@ -14,6 +14,7 @@ library(vroom)
 dotenv::load_dot_env()
 source("expected_columns.R")
 source("R/functions_prep_project.R")
+source("R/plots.R")
 
 # set up project----
 if (file.exists(here::here(".env"))) {
@@ -173,6 +174,47 @@ if (!is.null(data_sankey_company_sector)) {
     data_sankey_company_sector,
     save_png_to = output_path_aggregated,
     png_name = "plot_sankey_company_sector.png"
+  )
+}
+
+### scatter plot alignment by exposure and sector comparison----
+year_scatter_alignment_exposure <- 2027
+region_scatter_alignment_exposure <- region_select
+# TODO: this should come from the loan book
+currency <- "EUR"
+category <- "group_id"
+
+if (
+  nrow(loanbook_exposure_aggregated_alignment_net) > 0
+) {
+  data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
+    prep_scatter_alignment_exposure(
+      year = year_scatter_alignment_exposure,
+      region = region_scatter_alignment_exposure,
+      scenario = scenario_select
+    )
+
+  data_scatter_alignment_exposure %>%
+    readr::write_csv(
+      file = file.path(
+        output_path_aggregated,
+        "data_scatter_alignment_exposure.csv"
+      )
+    )
+
+  plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
+    plot_scatter_alignment_exposure(
+      floor_outliers = -1,
+      cap_outliers = 1,
+      category = category,
+      currency = currency
+    )
+
+  ggplot2::ggsave(
+    filename = "plot_scatter_alignment_exposure.png",
+    path = output_path_aggregated,
+    width = 8,
+    height = 5
   )
 }
 

--- a/plot_aggregate_loanbooks.R
+++ b/plot_aggregate_loanbooks.R
@@ -181,7 +181,7 @@ if (!is.null(data_sankey_company_sector)) {
 year_scatter_alignment_exposure <- 2027
 region_scatter_alignment_exposure <- region_select
 # TODO: this should come from the loan book
-currency <- "EUR"
+currency <- unique(matched_prioritized$loan_size_outstanding_currency)
 category <- "group_id"
 
 if (
@@ -214,7 +214,9 @@ if (
     filename = "plot_scatter_alignment_exposure.png",
     path = output_path_aggregated,
     width = 8,
-    height = 5
+    height = 5,
+    dpi = 300,
+    units = "in",
   )
 }
 

--- a/plot_aggregate_loanbooks.R
+++ b/plot_aggregate_loanbooks.R
@@ -191,7 +191,9 @@ if (
     prep_scatter_alignment_exposure(
       year = year_scatter_alignment_exposure,
       region = region_scatter_alignment_exposure,
-      scenario = scenario_select
+      scenario = scenario_select,
+      category = category,
+      exclude_group_ids = "benchmark"
     )
 
   data_scatter_alignment_exposure %>%


### PR DESCRIPTION
To provide an additional overview chart for an ongoing project, we want to display the net aggregate alignment metric by financial exposure at the sector level and by categories, such as the name of the loan book or the type of bank.
Thus, `workflow.aggregate.loanbooks`...
- gains functions `prep_scatter_alignment_exposure` and `plot_scatter_alignment_exposure`, both stored in R/plots.R
- calls new functions in the main plot generation script `plot_aggregate_loanbooks.R`

NOTE
- once we have a clearer view of the P4S product, this function may need to be moved to a package and exported
- in that case it would likely undergo further visual improvements