### PR TITLE
nit: modernize `README.md` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Scripts will be found at root level.
 The scripts depend on a number of PACTA related R packages, most of which can be found on CRAN. However, you will need to install the development version of `pacta.aggregate.loanbook.plots` from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("RMI-PACTA/pacta.aggregate.loanbook.plots")
+# install.packages("pak")
+pak::pak("RMI-PACTA/pacta.aggregate.loanbook.plots")
 ```
 
 ## dotenv


### PR DESCRIPTION
`pak::pak` now seems to be preferred over `devtools::install_github` by `tidyverse` et al:

https://github.com/tidyverse/dplyr/blob/d69802224a1df16d7a795ce313880116ea62ed6e/README.md