### PR TITLE
rm superfluous handling of NAs in abcd when PACTA is run

### DIFF
--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -83,8 +83,6 @@ abcd <- readr::read_csv(
   col_types = col_types_abcd,
   col_select = dplyr::all_of(col_select_abcd)
 )
-# replace potential NA values with 0 in production
-abcd["production"][is.na(abcd["production"])] <- 0
 
 # optional: remove company-sector combinations where production in t5 = 0 when
 # it was greater than 0 in t0.

--- a/run_pacta_in_bulk.R
+++ b/run_pacta_in_bulk.R
@@ -85,8 +85,6 @@ abcd <- readr::read_csv(
   col_types = col_types_abcd,
   col_select = dplyr::all_of(col_select_abcd)
 )
-# replace potential NA values with 0 in production
-abcd["production"][is.na(abcd["production"])] <- 0
 
 # optional: remove company-sector combinations where production in t5 = 0 when
 # it was greater than 0 in t0.


### PR DESCRIPTION
closes #74 

- running PACTA `target_market_share()` calculation handles missing values in `production` column: https://github.com/RMI-PACTA/r2dii.analysis/pull/460
- removes manual replacement of `NA`s for `production` in `abcd`, when `target_market_share()` is applied:
  - `run_pacta_in_bulk.R`
  - `run_aggregate_loanbooks.R`