### PR TITLE
switch to package pacta.multi.loanbook.analysis

### DIFF
--- a/R/functions_prep_project.R
+++ b/R/functions_prep_project.R
@@ -375,7 +375,7 @@ validate_input_args_sample_raw_loanbook_from_abcd <- function(n_companies,
 
 validate_input_data_sample_raw_loanbook_from_abcd <- function(abcd,
                                                               sector_shares) {
-  pacta.aggregate.loanbook.plots::validate_data_has_expected_cols(
+  pacta.multi.loanbook.analysis::validate_data_has_expected_cols(
     data = abcd,
     expected_columns = c(
       "company_id", "name_company", "lei", "is_ultimate_owner", "sector",
@@ -384,7 +384,7 @@ validate_input_data_sample_raw_loanbook_from_abcd <- function(abcd,
     )
   )
 
-  pacta.aggregate.loanbook.plots::validate_data_has_expected_cols(
+  pacta.multi.loanbook.analysis::validate_data_has_expected_cols(
     data = sector_shares,
     expected_columns = c(
       "sector", "share"

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Scripts will be found at root level.
 
 ## Installation
 
-The scripts depend on a number of PACTA related R packages, most of which can be found on CRAN. However, you will need to install the development version of `pacta.aggregate.loanbook.plots` from [GitHub](https://github.com/) with:
+The scripts depend on a number of PACTA related R packages, most of which can be found on CRAN. However, you will need to install the development version of `pacta.multi.loanbook.analysis` from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("pak")
-pak::pak("RMI-PACTA/pacta.aggregate.loanbook.plots")
+pak::pak("RMI-PACTA/pacta.multi.loanbook.analysis")
 ```
 
 ## dotenv

--- a/plot_aggregate_loanbooks.R
+++ b/plot_aggregate_loanbooks.R
@@ -1,7 +1,7 @@
 # load packages----
 library(dotenv)
 library(dplyr)
-library(pacta.aggregate.loanbook.plots)
+library(pacta.multi.loanbook.analysis)
 library(r2dii.analysis)
 library(r2dii.data)
 library(r2dii.match)

--- a/prep_sample_loanbook_raw.R
+++ b/prep_sample_loanbook_raw.R
@@ -1,7 +1,7 @@
 # load packages----
 library(dotenv)
 library(dplyr)
-library(pacta.aggregate.loanbook.plots)
+library(pacta.multi.loanbook.analysis)
 library(r2dii.data)
 library(readxl)
 library(rlang)

--- a/run_aggregate_loanbooks.R
+++ b/run_aggregate_loanbooks.R
@@ -1,7 +1,7 @@
 # load packages----
 library(dotenv)
 library(dplyr)
-library(pacta.aggregate.loanbook.plots)
+library(pacta.multi.loanbook.analysis)
 library(r2dii.analysis)
 library(r2dii.data)
 library(r2dii.match)

--- a/run_pacta_in_bulk.R
+++ b/run_pacta_in_bulk.R
@@ -1,7 +1,7 @@
 # load packages----
 library(dotenv)
 library(dplyr)
-library(pacta.aggregate.loanbook.plots)
+library(pacta.multi.loanbook.analysis)
 library(r2dii.analysis)
 library(r2dii.data)
 library(r2dii.match)


### PR DESCRIPTION
closes #82 

- all references of `pacta.aggregate.loanbook.plots` change to `pacta.multi.loanbook.analysis`