### PR TITLE
replace code_level with nchar

### DIFF
--- a/R/functions_prep_project.R
+++ b/R/functions_prep_project.R
@@ -253,7 +253,7 @@ sample_raw_loanbook_from_abcd <- function(abcd = NULL,
   sample_sector_codes <- r2dii.data::nace_classification %>%
     dplyr::filter(.data$borderline == FALSE) %>%
     dplyr::group_by(.data$sector) %>%
-    dplyr::slice_max(.data$code_level, n = 1) %>%
+    dplyr::slice_max(nchar(.data$code), n = 1) %>%
     dplyr::slice_head(n = 1) %>%
     dplyr::ungroup() %>%
     dplyr::select("sector", "code") %>%


### PR DESCRIPTION
closes #90 

- replaces `max(code_level)` with `max(nchar(code))` to identify sector codes at the most granular level, as code_level was deprecated from `r2dii.data`